### PR TITLE
Fix scoreboard prefab path to prevent null references

### DIFF
--- a/Assets/Scripts/GlobalScoreboardMenuUI.cs
+++ b/Assets/Scripts/GlobalScoreboardMenuUI.cs
@@ -125,8 +125,8 @@ public class GlobalScoreboardMenuUI : MonoBehaviour
         foreach (var entry in topScores)
         {
             GameObject item = Instantiate(scoreItemPrefab, contentRoot);
-            item.transform.Find("NameText").GetComponent<TMP_Text>().text = entry.playerName;
-            item.transform.Find("ScoreText").GetComponent<TMP_Text>().text = entry.score.ToString();
+            item.transform.Find("Canvas/NameText").GetComponent<TMP_Text>().text = entry.playerName;
+            item.transform.Find("Canvas/ScoreText").GetComponent<TMP_Text>().text = entry.score.ToString();
         }
     }
 


### PR DESCRIPTION
## Summary
- fix scoreboard prefab child path in `GlobalScoreboardMenuUI`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685306c4de38832baf5a88449765f633