### PR TITLE
Add global leaderboard API integration

### DIFF
--- a/Assets/Scripts/GlobalScoreboardMenuUI.cs
+++ b/Assets/Scripts/GlobalScoreboardMenuUI.cs
@@ -125,14 +125,23 @@ public class GlobalScoreboardMenuUI : MonoBehaviour
             return;
         }
 
-        List<GlobalScoreEntry> topScores = GlobalScoreBoardManager.Instance.GetTopScores();
-        Debug.Log("[GlobalScoreboardMenuUI] Top Scores size: " + topScores.Count);
+        if (LeaderboardApiClient.Instance != null)
+        {
+            StartCoroutine(LeaderboardApiClient.Instance.FetchScores(OnScoresFetched));
+        }
+        else
+        {
+            Debug.LogError("[GlobalScoreboardMenuUI] LeaderboardApiClient instance not found.");
+        }
+    }
 
-        foreach (var entry in topScores)
+    private void OnScoresFetched(List<GlobalScoreEntry> scores)
+    {
+        scores.Sort((a, b) => b.score.CompareTo(a.score));
+
+        foreach (var entry in scores)
         {
             GameObject item = Instantiate(scoreItemPrefab, contentRoot);
-            Debug.Log("[GlobalScoreboardMenuUI] Created score item for player: " + entry.playerName);
-        
             item.transform.Find("NameText").GetComponent<TMP_Text>().text = entry.playerName;
             item.transform.Find("ScoreText").GetComponent<TMP_Text>().text = entry.score.ToString();
         }

--- a/Assets/Scripts/Managers/LeaderboardApiClient.cs
+++ b/Assets/Scripts/Managers/LeaderboardApiClient.cs
@@ -1,0 +1,53 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Networking;
+
+public class LeaderboardApiClient : MonoBehaviour
+{
+    public static LeaderboardApiClient Instance;
+
+    [SerializeField] private string apiUrl = "https://example.com/api/scores"; // TODO: change to your API endpoint
+
+    private void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+        else
+        {
+            Destroy(gameObject);
+        }
+    }
+
+    public IEnumerator FetchScores(System.Action<List<GlobalScoreEntry>> onResult)
+    {
+        using (UnityWebRequest request = UnityWebRequest.Get(apiUrl))
+        {
+            yield return request.SendWebRequest();
+
+            if (request.result != UnityWebRequest.Result.Success)
+            {
+                Debug.LogError("[LeaderboardApiClient] Failed to fetch scores: " + request.error);
+                onResult?.Invoke(new List<GlobalScoreEntry>());
+            }
+            else
+            {
+                string json = request.downloadHandler.text;
+                ScoreListWrapper wrapper = JsonUtility.FromJson<ScoreListWrapper>(json);
+                if (wrapper != null && wrapper.scores != null)
+                    onResult?.Invoke(wrapper.scores);
+                else
+                    onResult?.Invoke(new List<GlobalScoreEntry>());
+            }
+        }
+    }
+
+    [System.Serializable]
+    private class ScoreListWrapper
+    {
+        public List<GlobalScoreEntry> scores;
+    }
+}


### PR DESCRIPTION
## Summary
- add `LeaderboardApiClient` to fetch scores from a web API
- update `GlobalScoreboardMenuUI` to request scores via the API and display them sorted

